### PR TITLE
adds readStream destroy call to lecture7 wordFind activities

### DIFF
--- a/lecture7/wordFind.js
+++ b/lecture7/wordFind.js
@@ -21,7 +21,10 @@ readStream.on("data", function(blob) {
 			console.log("Read " + blob.length +  " bytes");
 			var newBlob = oldBlob + blob;
 			index = newBlob.indexOf(textToFind);
-			if (index >= 0) readStream.emit("end");
+			if (index >= 0) {
+				readStream.emit("end");
+				readStream.destroy();
+			}
 			oldBlob = blob;
 		} );
 
@@ -36,4 +39,3 @@ readStream.on("error", function() {
 		console.log("Error occurred when reading from file " + fileName);
 	} );
 
-console.log("End of program");

--- a/lecture7/wordFind.js
+++ b/lecture7/wordFind.js
@@ -39,3 +39,4 @@ readStream.on("error", function() {
 		console.log("Error occurred when reading from file " + fileName);
 	} );
 
+console.log("End of program");

--- a/lecture7/wordFind2.js
+++ b/lecture7/wordFind2.js
@@ -51,3 +51,5 @@ readStream.on("end", function() {
 readStream.on("error", function() {
 		console.log("Error occurred when reading from file " + fileName);
 	} );
+
+console.log("End of program");

--- a/lecture7/wordFind2.js
+++ b/lecture7/wordFind2.js
@@ -30,6 +30,7 @@ readStream.on("data", function(blob) {
 					// If all the characters match, we have found it
 					index = i;
 					readStream.emit("end");	
+					readStream.destroy();
 					break;
 				}
 			} else if (matchIndex > 0){
@@ -50,5 +51,3 @@ readStream.on("end", function() {
 readStream.on("error", function() {
 		console.log("Error occurred when reading from file " + fileName);
 	} );
-
-console.log("End of program");


### PR DESCRIPTION
In later version of node.js (tested on v16), calling emit("end") method on a read stream triggers the end event, but does not kill the read stream. Adds destroy() call to kill read stream. 