### PR TITLE
Fixed lect7 ajaxserver-solution, filename error

### DIFF
--- a/lecture7/ajaxserver-solution.js
+++ b/lecture7/ajaxserver-solution.js
@@ -19,7 +19,7 @@ var serveRequest = function(request, response) {
 		else
 			counts[addr] = 0;
 		var instance = counts[addr];
-		var fileName = path + "/file"+ addr.replace(/:/g,'');
+		var fileName = path + "/file"+ instance;
 		console.log(fileName);
 		fs.appendFile(fileName, request.url + "\n", function(err) {
 			if (err) console.log("Error writing to file " + fileName);	

--- a/lecture7/ajaxserver-solution.js
+++ b/lecture7/ajaxserver-solution.js
@@ -19,7 +19,7 @@ var serveRequest = function(request, response) {
 		else
 			counts[addr] = 0;
 		var instance = counts[addr];
-		var fileName = path + "/file"+ addr;
+		var fileName = path + "/file"+ addr.replace(/:/g,'');
 		console.log(fileName);
 		fs.appendFile(fileName, request.url + "\n", function(err) {
 			if (err) console.log("Error writing to file " + fileName);	


### PR DESCRIPTION
Changed 'addr' to 'instance', so fileName doesn't contain colons, no error for Windows user now